### PR TITLE
[DOCS] Move architecture section to Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,11 @@
 # gsh
 
 GSH is an OpenID Connect-compatible authentication system for systems using OpenSSH servers consisting of an out-of-box binary set.
-Its use requires only a few configurations in the sshd_config file, allowing for a staged migration of an infrastructure based on PAM  authentication (LDAP/AD/Kerberos/etc) to an authentication structure used for OpenID Connect and SSH certificates.
+Its use requires only a few configurations in the `sshd_config` file, allowing for a staged migration of an infrastructure based on PAM authentication (LDAP/AD/Kerberos/etc) to an authentication structure with OpenID Connect and SSH certificates.
 
-## Architecture
+## Want to know more?
 
-- **GSH API** is responsible for authenticating and authorizing (via OpenID Connect) users who want to access some host using OpenSSH. The information provided via OpenID Connect is processed in the API to verify that the user can access the host and with which user the user can access.
-After the validations, a certificate is issued and made available to the user for access to the requested host.
-
-- **GSH Client** is responsible for communicating with the GSH API and performing the certificate requests. The client also has the stream that enables the client to authenticate locally using the terminal (via OpenID Connect).
-
-- **GSH Command** is responsible for making auditing of the commands executed on the servers possible. When generating a certificate, the GSH API can include the force-command attribute where the OpenSSH server will run the GSH Command. This binary will send all the commands to the GSH API making it possible to audit everything that was done using the certificate issued for that connection.
-The command is also responsible for enabling remote management of sessions, for example by enabling unauthorized session interruption.
-
-- **GSH Agent** is responsible for periodically rotating the CA keys on the servers and signing the host keys in order to avoid TOFU problems. It runs in crontab and is installed by the GSH API.
-
-- **GSH Principals** is responsible for confirming the mapping performed on the server-side certificate. It runs every time a certificate authentication is performed on the OpenSSH server and queries the GSH API to confirm the operation.
-
-## User flow (terminal)
-
-1. User runs `gsh 10.10.10.10` client
-2. The client checks to see if an OpenID Connect JWT already exists in the `~/.gsh` directory of the user. If it exists and it is valid, it goes to step 1.5, if it does not exist or is not valid, it continues in 1.2
-3. The client starts a local web server and redirects the user to the OpenID provider by pointing the local web server as the return URL
-4. The user authenticates and the browser redirects the `code` to the client on the local web server
-5. The client, with `code`, requests the user's access token (JWT).
-6. The client, with the user's JWT, generates an SSH key pair and sends [a request to the API](https://github.com/globocom/gsh/wiki/routes-post-certificates)
-7. The API processes the request, verifying that the user has the appropriate permissions and generates a certificate for the user
-8. The client, with the SSH certificate and the keys already generated, makes a connection [using SSH on the server](https://github.com/globocom/gsh/wiki/manual-openssh-client)
-
-## User flow (web)
-
-1. User authenticates in web interface at gsh.example.com
-2. The gsh.example.com application verifies that the user has a valid session if he does not redirect the user to the OpenID Connect authentication.
-3. The user selects the server he would like to have access to and the configuration parameters (access time, remote user, key to be used)
-4. The web interface generates a certificate for the user
-5. The user uses the certificate to [connect to the server](https://github.com/globocom/gsh/wiki/manual-openssh-client)
-
-## Server flow
-
-1. The server receives the connection with the user's certificate
-2. The SSH server checks if the certificate is signed by [one of the configured CAs] (https://man.openbsd.org/sshd_config#TrustedUserCAKeys)
-3. The SSH server checks if the `principal` attribute in the certificate is valid using [gsh-command] (https://man.openbsd.org/sshd_config#AuthorizedPrincipalsCommand)
-4. `gsh-command` receives the parameters of the certificate and verifies in the GSH API if that connection should be authorized. If it is not, it blocks the connection, if it does, it returns the [server-expected configuration] (http://man.openbsd.org/sshd.8#AUTHORIZED_KEYS_FILE_FORMAT)
-5. The SSH server checks whether the certificate has the `force-command` attribute. If it does, it executes `gsh-shell` which makes it possible to audit the commands performed on the accessed host.
+Take a look at our excellent [documentation](https://github.com/globocom/gsh/wiki)!
 
 ## References
 


### PR DESCRIPTION
The README file was too large with the architecture documentation. I moved the architecture documentation to the wiki so that it had more flexibility to update and leave the README with only quick links.

Architecture page updated:
- [GSH Architecture](https://github.com/globocom/gsh/wiki/architecture)