### PR TITLE
api: [FIX] Add query escape and un-escape functions to parse keyID in /certificates/* route

### DIFF
--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -184,7 +185,7 @@ func getCertInfo(keyID string, api string) (CertInfo, error) {
 	}
 
 	// Get certificate from API
-	resp, err := netClient.Get(api + "/certificates/" + keyID)
+	resp, err := netClient.Get(api + "/certificates/" + url.QueryEscape(keyID))
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"event":  "get certinfo",

--- a/api/main.go
+++ b/api/main.go
@@ -51,7 +51,7 @@ func main() {
 	e.GET("/status/ready", handlers.StatusReady)
 	e.GET("/status/config", appHandler.StatusConfig)
 	e.GET("/publickey", appHandler.PublicKey)
-	e.GET("/certificates/:keyID", appHandler.CertInfo)
+	e.GET("/certificates/*", appHandler.CertInfo)
 
 	e.POST("/certificates", appHandler.CertCreate)
 


### PR DESCRIPTION
This commit aims to add the query escape function to `/certificates/*` route in `checkPermissions.go` and query unescape to certificate request in `certificates.go`.