### PR TITLE
api: [FIX] Verify if command is sent to API before set at critical options

### DIFF
--- a/api/handlers/certificates.go
+++ b/api/handlers/certificates.go
@@ -33,7 +33,7 @@ type certConfig struct {
 // 	"remote_user":"jim",
 //  "remote_host":"192.168.2.105",
 // 	"user_ip":"192.168.2.5",
-//	"jwt": "...."
+// 	"command":"/bin/bash"
 // }
 //
 // - Output sample


### PR DESCRIPTION
This PR fix `force-command` option at API. 

Before, when using an internal CA, API logic requires the `force-command` value, but is not  required with external CA.
This PR make `force-command` as not required.