### PR TITLE
[FIX] api/agent - using serial number instead of key id from certificate

### DIFF
--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -16,12 +16,12 @@ import (
 
 func init() {
 	rootCmd.AddCommand(checkPermissionCmd)
-	checkPermissionCmd.Flags().String("key-id", "", "the key-id of the ssh certificate")
+	checkPermissionCmd.Flags().String("serial-number", "", "the serial-number of the ssh certificate")
 	checkPermissionCmd.Flags().String("username", "", "the username of the user trying to authenticate")
 	checkPermissionCmd.Flags().String("api", "", "the endpoint GSH API to check certificate")
 }
 
-// CertInfo is struct with response for GET /certificate/:keyID
+// CertInfo is struct with response for GET /certificate/:serialNumber
 type CertInfo struct {
 	Result     string `json:"result"`
 	RemoteUser string `json:"remote_user"`
@@ -62,15 +62,15 @@ var checkPermissionCmd = &cobra.Command{
 			defer file.Close()
 		}
 
-		// Get key-id flag
-		keyID, err := cmd.Flags().GetString("key-id")
+		// Get serial-number flag
+		serialNumber, err := cmd.Flags().GetString("serial-number")
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"event":  "reading flag parameter from sshd",
-				"topic":  "key-id not informed",
-				"key":    "key-id",
+				"topic":  "serial-number not informed",
+				"key":    "serial-number",
 				"result": "fail",
-			}).Fatal("Failed to read key-id")
+			}).Fatal("Failed to read serial-number")
 			os.Exit(-1)
 		}
 
@@ -87,7 +87,7 @@ var checkPermissionCmd = &cobra.Command{
 		}
 
 		// Defining default field to log
-		auditLogger := log.WithFields(logrus.Fields{"key_id": keyID, "username": username})
+		auditLogger := log.WithFields(logrus.Fields{"serial_number": serialNumber, "username": username})
 
 		// Get GSH API endpoint
 		api, err := cmd.Flags().GetString("api")
@@ -102,7 +102,7 @@ var checkPermissionCmd = &cobra.Command{
 		}
 
 		// Get certificate from GSH API
-		certInfo, err := getCertInfo(keyID, api)
+		certInfo, err := getCertInfo(serialNumber, api)
 		if err != nil {
 			auditLogger.WithFields(logrus.Fields{
 				"event":  "certinfo error validation",
@@ -169,8 +169,8 @@ func checkInterfaces(remoteHost string) bool {
 	return false
 }
 
-// getCertInfo reveives a keyID and check on GSH API for certificate
-func getCertInfo(keyID string, api string) (CertInfo, error) {
+// getCertInfo reveives a serialNumber and check on GSH API for certificate
+func getCertInfo(serialNumber string, api string) (CertInfo, error) {
 
 	// Setting custom HTTP client with timeouts
 	var netTransport = &http.Transport{
@@ -185,7 +185,7 @@ func getCertInfo(keyID string, api string) (CertInfo, error) {
 	}
 
 	// Get certificate from API
-	resp, err := netClient.Get(api + "/certificates/" + url.QueryEscape(keyID))
+	resp, err := netClient.Get(api + "/certificates/" + url.QueryEscape(serialNumber))
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"event":  "get certinfo",

--- a/api/handlers/certificates.go
+++ b/api/handlers/certificates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -204,6 +205,7 @@ func (h AppHandler) CertCreate(c echo.Context) error {
 	signedCert := k.(*ssh.Certificate)
 	//assigning the new key id to store the new value into db
 	certRequest.CertKeyID = signedCert.KeyId
+	certRequest.SerialNumber = strconv.FormatUint(signedCert.Serial, 10)
 	// storing certificate in database
 	dbc := h.db.Create(certRequest)
 	if h.db.NewRecord(certRequest) {
@@ -271,14 +273,15 @@ func (h AppHandler) PublicKey(c echo.Context) error {
 func (h AppHandler) CertInfo(c echo.Context) error {
 	keyPath := c.Request().RequestURI
 	s := strings.SplitAfterN(keyPath, "/", 3)
-	keyID := s[2]
-	keyID, err := url.QueryUnescape(keyID)
+	serialNumber := s[2]
+	serialNumber, err := url.QueryUnescape(serialNumber)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError,
 			map[string]string{"result": "fail", "message": "Error unescaping url query", "details": err.Error()})
 	}
 	certRequest := new(types.CertRequest)
-	h.db.Where("cert_key_id = ?", keyID).First(&certRequest)
+	//sshd only gives 15 characters for serial number
+	h.db.Where("cert_serial_number LIKE ?", serialNumber+"%").First(&certRequest)
 
 	return c.JSON(http.StatusOK, map[string]string{"result": "succes", "remote_user": certRequest.RemoteUser, "remote_host": certRequest.RemoteHost})
 }

--- a/types/certificate.go
+++ b/types/certificate.go
@@ -25,8 +25,9 @@ type CertRequest struct {
 	CAFingerprint string        `json:"-" gorm:"column:ca_fingerprint"`
 	KeyID         string        `json:"-" gorm:"column:key_id"`
 
-	//Certificate KeyID, after signed
-	CertKeyID string `json:"-" gorm:"column:cert_key_id"`
+	//Certificate KeyID and Serial Number, after signed
+	CertKeyID    string `json:"-" gorm:"column:cert_key_id"`
+	SerialNumber string `json:"-" gorm:"column:cert_serial_number"`
 
 	// Columns for database
 	ID         uint       `json:"-" gorm:"primary_key"`


### PR DESCRIPTION
Regarding issue #29 

Storing serial number provided from CA after the certificate is signed, and looking for it when the agent asks for certificate information.

Issue found: `sshd` will only show the first 15 characters of a serial number, so when querying the database for this record the `LIKE` operator was used.