### PR TITLE
[FEAT] Add error message at GSH CLI discovery

### DIFF
--- a/cli/cmd/auth/auth.go
+++ b/cli/cmd/auth/auth.go
@@ -201,7 +201,7 @@ func RecoverToken(currentTarget *types.Target) (*oauth2.Token, error) {
 	// Making discovery GSH request
 	resp, err := netClient.Get(currentTarget.Endpoint + "/status/config")
 	if err != nil {
-		fmt.Printf("GSH API is down: %s\n", currentTarget.Endpoint)
+		fmt.Printf("GSH API is down: %s (%s)\n", currentTarget.Endpoint, err.Error())
 		os.Exit(1)
 	}
 	defer resp.Body.Close()

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -90,7 +90,7 @@ func Discovery() (*DiscoveryResponse, error) {
 	// Making discovery GSH request
 	resp, err := netClient.Get(currentTarget.Endpoint + "/status/config")
 	if err != nil {
-		fmt.Printf("GSH API is down: %s\n", currentTarget.Endpoint)
+		fmt.Printf("GSH API is down: %s (%s)\n", currentTarget.Endpoint, err.Error())
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -134,7 +134,7 @@ All gshc actions require the user to be authenticated (except [[gshc login]],
 		// Making discovery GSH request
 		resp, err := netClient.Get(currentTarget.Endpoint + "/status/config")
 		if err != nil {
-			fmt.Printf("GSH API is down: %s\n", currentTarget.Endpoint)
+			fmt.Printf("GSH API is down: %s (%s)\n", currentTarget.Endpoint, err.Error())
 			os.Exit(1)
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
This PR adds an error message when discovery requests fails at GSH API.

Example:
```
$ gsh login
Using config file: /Users/manoel.junior/.gshc/config.yaml

GSH API is down: https://gsh-api.example.com (Get https://gsh-api.example.com/status/config: x509: certificate signed by unknown authority)
```

This PR is related with golang at macos problem at https://github.com/golang/go/issues/24652.