### PR TITLE
[FIX] Change help text with gsh config YAML

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -71,7 +71,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gshc.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gshc/config.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directlßy.


### PR DESCRIPTION
This PR change help text when gsh-cli shows help text.

Before, gsh cli show config location has `$HOME/.gshc.yaml`  but config location is `$HOME/.gshc/config.yaml`.

Before:
```
Flags:
      --config string   config file (default is $HOME/.gshc.yaml)
  -h, --help            help for gshc
  -t, --toggle          Help message for toggle

Use "gshc [command] --help" for more information about a command.
```

After:
```
Flags:
      --config string   config file (default is $HOME/.gshc/config.yaml)
  -h, --help            help for gshc
  -t, --toggle          Help message for toggle

Use "gshc [command] --help" for more information about a command.
```