### PR TITLE
[FIX] Improve error handling when target is not defined

### DIFF
--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -60,7 +60,7 @@ func GetCurrentTarget() *types.Target {
 
 		// check if target is properly configured
 		if target["current"] == nil {
-			fmt.Printf("You need configure a target using target-add command\n")
+			fmt.Printf("You need to configure a target using target-add command\n")
 			os.Exit(1)
 		}
 

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -35,6 +35,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/globocom/gsh/types"
@@ -56,6 +57,12 @@ func GetCurrentTarget() *types.Target {
 	targets := viper.GetStringMap("targets")
 	for k, v := range targets {
 		target := v.(map[string]interface{})
+
+		// check if target is properly configured
+		if target["current"] == nil {
+			fmt.Printf("You need configure a target using target-add command\n")
+			os.Exit(1)
+		}
 
 		if target["current"] != nil {
 			// format output for activated target

--- a/cli/cmd/hostConnect.go
+++ b/cli/cmd/hostConnect.go
@@ -53,7 +53,6 @@ import (
 	"github.com/globocom/gsh/cli/cmd/files"
 	"github.com/globocom/gsh/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/oauth2"
 )
@@ -71,16 +70,7 @@ can access an host just giving DNS name, or specifying the IP of the host.
 
 		// Get current target
 		currentTarget := new(types.Target)
-		targets := viper.GetStringMap("targets")
-		for k, v := range targets {
-			target := v.(map[string]interface{})
-
-			// format output for activated target
-			if target["current"].(bool) {
-				currentTarget.Label = k
-				currentTarget.Endpoint = target["endpoint"].(string)
-			}
-		}
+		currentTarget = config.GetCurrentTarget()
 
 		// Keys struct for reuse
 		type Keys struct {

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -44,6 +44,7 @@ import (
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/globocom/gsh/cli/cmd/auth"
+	"github.com/globocom/gsh/cli/cmd/config"
 	"github.com/globocom/gsh/types"
 	"github.com/labstack/gommon/random"
 	"github.com/spf13/cobra"
@@ -68,16 +69,7 @@ All gshc actions require the user to be authenticated (except [[gshc login]],
 
 		// Get current target
 		currentTarget := new(types.Target)
-		targets := viper.GetStringMap("targets")
-		for k, v := range targets {
-			target := v.(map[string]interface{})
-
-			// format output for activated target
-			if target["current"].(bool) {
-				currentTarget.Label = k
-				currentTarget.Endpoint = target["endpoint"].(string)
-			}
-		}
+		currentTarget = config.GetCurrentTarget()
 
 		// Check for set-token-storage flag
 		var setStorage string


### PR DESCRIPTION
This PR fixes a issue when a user uses `gsh login` or `gsh host-connect` before setting a target.

Exemple of error:
```
Using config file: /Users/manoel.junior/.gshc/config.yaml

panic: interface conversion: interface {} is nil, not bool

goroutine 1 [running]:
github.com/globocom/gsh/cli/cmd.glob..func2(0x4982020, 0xc000057590, 0x1, 0x1)
	/Users/manoel.junior/go/src/github.com/globocom/gsh/cli/cmd/login.go:81 +0x1983
github.com/globocom/gsh/vendor/github.com/spf13/cobra.(*Command).execute(0x4982020, 0xc000057550, 0x1, 0x1, 0x4982020, 0xc000057550)
	/Users/manoel.junior/go/src/github.com/globocom/gsh/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/globocom/gsh/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x4982280, 0x0, 0x4982c00, 0xc00011df58)
	/Users/manoel.junior/go/src/github.com/globocom/gsh/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/globocom/gsh/vendor/github.com/spf13/cobra.(*Command).Execute(0x4982280, 0x4007920, 0xc000084058)
	/Users/manoel.junior/go/src/github.com/globocom/gsh/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/globocom/gsh/cli/cmd.Execute()
	/Users/manoel.junior/go/src/github.com/globocom/gsh/cli/cmd/root.go:62 +0x2d
main.main()
	/Users/manoel.junior/go/src/github.com/globocom/gsh/cli/main.go:35 +0x20
```

After this PR:
```
Using config file: /Users/manoel.junior/.gshc/config.yaml

You need configure a target using target-add command
```