### PR TITLE
[REFACT] Fix how GSH CLI handles username

### DIFF
--- a/api/handlers/jwt.go
+++ b/api/handlers/jwt.go
@@ -252,3 +252,22 @@ func (j *jsonTime) UnmarshalJSON(b []byte) error {
 	*j = jsonTime(time.Unix(unix, 0))
 	return nil
 }
+
+// GetClaim returns a claim from JWT
+func GetClaim(jwt string, claim string) (string, error) {
+	var err error
+	token := IDToken{}
+
+	// Parse JWT
+	token, err = parseIDToken(jwt)
+	if err != nil {
+		return "", fmt.Errorf("GetClaim: %v", err.Error())
+	}
+
+	field, err := getField(&token, claim)
+	if err != nil {
+		return "", fmt.Errorf("GetClaim: The field declared in oidc_claim doesn't exist (%v) [%s]", err.Error(), jwt)
+	}
+
+	return field, nil
+}

--- a/api/handlers/status.go
+++ b/api/handlers/status.go
@@ -22,5 +22,6 @@ func (h AppHandler) StatusConfig(c echo.Context) error {
 		"oidc_base_url": h.config.GetString("oidc_base_url"),
 		"oidc_realm":    h.config.GetString("oidc_realm"),
 		"oidc_audience": h.config.GetString("oidc_audience"),
+		"oidc_claim":    h.config.GetString("oidc_claim"),
 	})
 }

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -47,7 +47,7 @@ type DiscoveryResponse struct {
 	BaseURL       string `json:"oidc_base_url"`
 	Realm         string `json:"oidc_realm"`
 	Audience      string `json:"oidc_audience"`
-	UsernameClaim string `json:"oidc_username_claim"`
+	UsernameClaim string `json:"oidc_claim"`
 }
 
 // GetCurrentTarget return a types.Target with current target


### PR DESCRIPTION
This PR refact the way that GSH CLI handles username for an user. Before, GSH CLI uses UserInfo route from OpenID Provider while the GSH API inspects the IDToken.

Maintain this different behavior is not practical because GSH CLI makes a discovery request at  GSH API that returns an OIDC claim name. This claim name is same for both, but using UserInfo route, the name of attribute is JSON key and using reflect at IDToken struct is another.

A better solution is create a new package to group all functions related with OpenID Connection. I'm doing this and adding tests in another branch [api-tests](https://github.com/globocom/gsh/tree/api-tests).