### PR TITLE
cli: [FIX] Fix target add command (not store targets at config file)

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -42,10 +42,10 @@ var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "gshc",
-	Short: "gshc is a CLI to use GSH",
+	Use:   "gsh",
+	Short: "gsh is a CLI to use GSH",
 	Long: `
-gshc is a CLI to use GSH.
+gsh is a CLI to use GSH.
 
 GSH is an OpenID Connect-compatible authentication system
 for OpenSSH servers. gshc uses certificate based authentication
@@ -92,13 +92,14 @@ func initConfig() {
 		}
 
 		// check if .gshc folder exists and creates if it not exists
-		path := home + "/.gshc"
+		path := home + "/.gsh"
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			err := os.Mkdir(path, 0750)
 			if err != nil {
 				fmt.Printf("Client error creating config folder: %s (%s)\n", path, err.Error())
 				os.Exit(1)
 			}
+			fmt.Printf("Client created config folder: %s\n", path)
 		}
 
 		// add path to viper config
@@ -117,14 +118,22 @@ func initConfig() {
 				fmt.Printf("Client error creating config file: %s (%s)\n", configFile, err.Error())
 				os.Exit(1)
 			}
-			defer f.Close()
+			err = f.Close()
+			if err != nil {
+				fmt.Printf("Client error closing config file: %s (%s)\n", configFile, err.Error())
+				os.Exit(1)
+			}
+			fmt.Printf("Client create new config file: %s\n", configFile)
 		}
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Printf("Using config file: %s\n\n", viper.ConfigFileUsed())
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Printf("Client error reading config file (%s)\n", err.Error())
+		os.Exit(1)
 	}
+	fmt.Printf("Using config file: %s\n\n", viper.ConfigFileUsed())
 }

--- a/cli/cmd/targetAdd.go
+++ b/cli/cmd/targetAdd.go
@@ -91,11 +91,13 @@ Adds a new entry to the list of available targets
 		targets[args[0]] = map[string]interface{}{"current": setCurrent, "endpoint": args[1]}
 
 		// save config
+		viper.Set("targets", targets)
 		err = viper.WriteConfig()
 		if err != nil {
 			fmt.Printf("Client error saving config with new target: (%s)\n", err.Error())
 			os.Exit(1)
 		}
+		fmt.Printf("New target %s -> %s added to target list\n", args[0], args[1])
 	},
 }
 

--- a/cli/cmd/targetRemove.go
+++ b/cli/cmd/targetRemove.go
@@ -62,7 +62,9 @@ var targetRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// remove entry from data struct
+		// remove entry from data struct but, before, storing data to show to user
+		target := targets[args[0]].(map[string]interface{})
+		endpoint := target["endpoint"].(string)
 		targets[args[0]] = nil
 
 		// save config
@@ -71,6 +73,7 @@ var targetRemoveCmd = &cobra.Command{
 			fmt.Printf("Client error saving config without target: (%s)\n", err.Error())
 			os.Exit(1)
 		}
+		fmt.Printf("Target %s -> %s removed from target list\n", args[0], endpoint)
 	},
 }
 

--- a/cli/cmd/targetSet.go
+++ b/cli/cmd/targetSet.go
@@ -51,6 +51,7 @@ Change current target (gsh api)
 
 		// check if target name is used
 		notUsed := true
+		endpoint := ""
 		targets := viper.GetStringMap("targets")
 		for k, v := range targets {
 			if k == args[0] {
@@ -58,6 +59,7 @@ Change current target (gsh api)
 				// set target as current
 				target := v.(map[string]interface{})
 				target["current"] = true
+				endpoint = target["endpoint"].(string)
 			} else {
 				// unset all others targets as not current
 				target := v.(map[string]interface{})
@@ -75,6 +77,7 @@ Change current target (gsh api)
 			fmt.Printf("Client error saving config with current target: (%s)\n", err.Error())
 			os.Exit(1)
 		}
+		fmt.Printf("New target is %s -> %s\n", args[0], endpoint)
 	},
 }
 


### PR DESCRIPTION
This PR fixes an incorrect behavior at `target-add` command.

Running `target-add` command before, new target is not add to config file:
```
$ gsh target-add example https://gsh-api.example.org -s
Using config file: /Users/manoel.junior/.gsh/config.yaml

$ cat /Users/manoel.junior/.gsh/config.yaml
{}
```

This error happen because `viper.Set()` is not invoked to save targets at config file. Is a simple commit (1 line) 1202cd455d41b595a7a539a39836a27e90192b9e.

Other points is that `target-*` commands don't have a result message to user. Example:
```
$ gsh target-add example https://gsh-api.example.org -s
Using config file: /Users/manoel.junior/.gsh/config.yaml

```
This PR addresses it, adding messages explaining to user what is happen after running command with success state ([wiki page updated](https://github.com/globocom/gsh/wiki/cli-commands#managing-remote-gsh-api-endpoints)).

Finally, this PR changes name of GSH CLI from `gshc` to `gsh` at code and wiki. Homebrew and snap installs GSH CLI as `gsh` command and at this way is more clear to user this name.
