### PR TITLE
cli: [FIX] Checks if token-storage is set at GetCurrentTarget()

### DIFF
--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/99designs/keyring"
 	"github.com/globocom/gsh/types"
 	"github.com/spf13/viper"
 )
@@ -69,7 +70,19 @@ func GetCurrentTarget() *types.Target {
 			if target["current"].(bool) {
 				currentTarget.Label = k
 				currentTarget.Endpoint = target["endpoint"].(string)
-				currentTarget.TokenStorage = target["token-storage"].(string)
+
+				// check token storage
+				var setStorage keyring.BackendType
+				if target["token-storage"] == nil {
+					tokenStorages := keyring.AvailableBackends()
+					if len(tokenStorages) > 0 {
+						setStorage = tokenStorages[0]
+					} else {
+						fmt.Printf("Client error with token storage: token storage not available\n")
+						os.Exit(1)
+					}
+				}
+				currentTarget.TokenStorage = string(setStorage)
 			}
 		}
 	}

--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -81,8 +81,9 @@ func GetCurrentTarget() *types.Target {
 						fmt.Printf("Client error with token storage: token storage not available\n")
 						os.Exit(1)
 					}
+					target["token-storage"] = string(setStorage)
 				}
-				currentTarget.TokenStorage = string(setStorage)
+				currentTarget.TokenStorage = target["token-storage"].(string)
 			}
 		}
 	}


### PR DESCRIPTION
This PR checks if a token-storage is configured when a command uses `config.GetCurrentTarget()` function.

If token-storage is not configured, GSH CLI uses package `99designs/keyring` to determine whats storage options is available. Thus, the first option is defined as default.