### PR TITLE
cli: [FIX] Configure others keyrings and forces users to set a token-storage

### DIFF
--- a/cli/cmd/config/config.go
+++ b/cli/cmd/config/config.go
@@ -38,7 +38,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/99designs/keyring"
 	"github.com/globocom/gsh/types"
 	"github.com/spf13/viper"
 )
@@ -72,18 +71,12 @@ func GetCurrentTarget() *types.Target {
 				currentTarget.Endpoint = target["endpoint"].(string)
 
 				// check token storage
-				var setStorage keyring.BackendType
 				if target["token-storage"] == nil {
-					tokenStorages := keyring.AvailableBackends()
-					if len(tokenStorages) > 0 {
-						setStorage = tokenStorages[0]
-					} else {
-						fmt.Printf("Client error with token storage: token storage not available\n")
-						os.Exit(1)
-					}
-					target["token-storage"] = string(setStorage)
+					fmt.Printf("Token storage is not set. You can set using -s flag at 'gsh login' command\n")
+					currentTarget.TokenStorage = ""
+				} else {
+					currentTarget.TokenStorage = target["token-storage"].(string)
 				}
-				currentTarget.TokenStorage = target["token-storage"].(string)
 			}
 		}
 	}

--- a/cli/cmd/files/files.go
+++ b/cli/cmd/files/files.go
@@ -48,8 +48,8 @@ func GetConfigPath() (string, error) {
 		return "", errors.New("File error finding homedir (" + err.Error() + ")")
 	}
 
-	// check if .gshc folder exists and creates if it not exists
-	path := home + "/.gshc"
+	// check if .gsh folder exists and creates if it not exists
+	path := home + "/.gsh"
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		err := os.Mkdir(path, 0750)
 		if err != nil {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -48,7 +48,7 @@ var rootCmd = &cobra.Command{
 gsh is a CLI to use GSH.
 
 GSH is an OpenID Connect-compatible authentication system
-for OpenSSH servers. gshc uses certificate based authentication
+for OpenSSH servers. gsh uses certificate based authentication
 on OpenSSH remote systems.`,
 
 	// Uncomment the following line if your bare application
@@ -71,7 +71,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gshc/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gsh/config.yaml)")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directlßy.
@@ -91,7 +91,7 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// check if .gshc folder exists and creates if it not exists
+		// check if .gsh folder exists and creates if it not exists
 		path := home + "/.gsh"
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			err := os.Mkdir(path, 0750)


### PR DESCRIPTION
This PR forces users to set a token-storage method instead set keychain as default. This is necessary so that the user can see the available options and can make the best choice according to their preferences.

One reason for this is that the GSH CLI binary can only access the Mac OS keychain from the user's home or if the binary is signed by an Apple Certificate. Therefore, by providing the available options, users can choose to put the binary in their home, use a signed version or choose another method of storing the credentials.

This PR also normalizes GSH folder to be `.gsh` at home folder. In old parts of the code, the folder was still `.gshc`.