### PR TITLE
[FEAT] Add gsh-agent and gsh-api support for key-id

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -58,7 +58,7 @@ func main() {
 	e.GET("/status/ready", handlers.StatusReady)
 	e.GET("/status/config", appHandler.StatusConfig)
 	e.GET("/publickey", appHandler.PublicKey)
-	e.GET("/certificates/*", appHandler.CertInfo)
+	e.GET("/certificates/:serial", appHandler.CertInfo)
 	e.POST("/certificates", appHandler.CertCreate)
 
 	e.GET("/authz/roles/me", appHandler.GetRolesForMe)


### PR DESCRIPTION
This PR adds support for gsh-agent and gsh-api handle key-id from certificates.

While OpenSSH doesn't handle appropriately serial number field, using key-id can improve the accuracy of searches for certificates.

Documentation is updated:
- https://github.com/globocom/gsh/wiki/agent-configuration
- https://github.com/globocom/gsh/wiki/api-routes-get-certificates_certificate