### PR TITLE
[FIX] Enable multiple IPs and improve audit records

### DIFF
--- a/api/handlers/certificates.go
+++ b/api/handlers/certificates.go
@@ -97,7 +97,10 @@ func (h AppHandler) CertCreate(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError,
 			map[string]string{"result": "fail", "message": "The field declared in oidc_claim doesn't exist", "details": err.Error()})
 	}
-	jti, _ := getField(&token, "JTI")
+	jti, err := getField(&token, "JTI")
+	if err != nil {
+		jti = ""
+	}
 
 	// Get user roles
 	err = h.permEnforcer.LoadPolicy()

--- a/api/handlers/jwt.go
+++ b/api/handlers/jwt.go
@@ -24,6 +24,7 @@ type IDToken struct {
 	AuthorizedParty   string                 `json:"azp"`
 	Expiry            jsonTime               `json:"exp"`
 	IssuedAt          jsonTime               `json:"iat"`
+	JTI               string                 `json:"jti"`
 	Nonce             string                 `json:"nonce"`
 	AtHash            string                 `json:"at_hash"`
 	Name              string                 `json:"name"`

--- a/api/permissions/enforcer.go
+++ b/api/permissions/enforcer.go
@@ -48,11 +48,11 @@ func Init(config viper.Viper) (*casbin.Enforcer, error) {
 		return nil, errors.New("Could not create new Enforcer")
 	}
 
-	// Enable multiples IP address as source or targets
-	e.AddFunction("ipMultipleMatch", IPMultipleMatchFunc)
-
 	e.SetModel(m)
 	e.EnableAutoSave(true)
+
+	// Enable multiples IP address as source or targets
+	e.AddFunction("ipMultipleMatch", IPMultipleMatchFunc)
 
 	// Reload policies from database before add admin policies
 	err = e.LoadPolicy()


### PR DESCRIPTION
This PR fixes the use of IPMultipleMatch at the permission model.

This PR also adds JTI and username by JWT at audit records. New audit records are generated for permissions errors.

This PR is a continuation from #43.