### PR TITLE
[FEAT] Adds support for the key's fingerprint validation

### DIFF
--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -229,7 +229,7 @@ func checkInterfaces(remoteHost string) bool {
 }
 
 // getCertInfo reveives a serialNumber and check on GSH API for certificate
-func getCertInfo(serialNumber string, keyID string, keyFingerprint string, cert string, certType string, api string) (CertInfo, error) {
+func getCertInfo(serialNumber, keyID, keyFingerprint, cert, certType, api string) (CertInfo, error) {
 
 	// Setting custom HTTP client with timeouts
 	var netTransport = &http.Transport{

--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -20,6 +20,8 @@ func init() {
 	checkPermissionCmd.Flags().String("username", "", "the username of the user trying to authenticate")
 	checkPermissionCmd.Flags().String("key-id", "", "the key-id of the ssh certificate")
 	checkPermissionCmd.Flags().String("key-fingerprint", "", "The fingerprint's public key used at an ssh certificate.")
+	checkPermissionCmd.Flags().String("certificate", "", "The base64-encoded certificate.")
+	checkPermissionCmd.Flags().String("certificate-type", "", "The certificate type.")
 	checkPermissionCmd.Flags().String("api", "", "the endpoint GSH API to check certificate")
 }
 
@@ -116,8 +118,35 @@ var checkPermissionCmd = &cobra.Command{
 			}).Error("Failed to read key_fingerprint")
 		}
 
+		cert, err := cmd.Flags().GetString("certificate")
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"event":  "reading flag parameter from sshd",
+				"topic":  "certificate not informed",
+				"key":    "certificate",
+				"result": "fail",
+			}).Error("Failed to read certificate")
+		}
+
+		certType, err := cmd.Flags().GetString("certificate-type")
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"event":  "reading flag parameter from sshd",
+				"topic":  "certificate-type not informed",
+				"key":    "certificate-type",
+				"result": "fail",
+			}).Error("Failed to read certificate-type")
+		}
+
 		// Defining default field to log
-		auditLogger := log.WithFields(logrus.Fields{"serial_number": serialNumber, "username": username, "key-id": keyID})
+		auditLogger := log.WithFields(logrus.Fields{
+			"serial_number":    serialNumber,
+			"username":         username,
+			"key-id":           keyID,
+			"key-fingerprint":  keyFingerprint,
+			"certificate":      cert,
+			"certificate-type": certType,
+		})
 
 		// Get GSH API endpoint
 		api, err := cmd.Flags().GetString("api")
@@ -132,7 +161,7 @@ var checkPermissionCmd = &cobra.Command{
 		}
 
 		// Get certificate from GSH API
-		certInfo, err := getCertInfo(serialNumber, keyID, keyFingerprint, api)
+		certInfo, err := getCertInfo(serialNumber, keyID, keyFingerprint, cert, certType, api)
 		if err != nil {
 			auditLogger.WithFields(logrus.Fields{
 				"event":  "certinfo error validation",
@@ -200,7 +229,7 @@ func checkInterfaces(remoteHost string) bool {
 }
 
 // getCertInfo reveives a serialNumber and check on GSH API for certificate
-func getCertInfo(serialNumber string, keyID string, keyFingerprint string, api string) (CertInfo, error) {
+func getCertInfo(serialNumber string, keyID string, keyFingerprint string, cert string, certType string, api string) (CertInfo, error) {
 
 	// Setting custom HTTP client with timeouts
 	var netTransport = &http.Transport{
@@ -215,7 +244,15 @@ func getCertInfo(serialNumber string, keyID string, keyFingerprint string, api s
 	}
 
 	// Get certificate from API
-	resp, err := netClient.Get(fmt.Sprintf("%s/certificates/%s?key_fingerprint=%s&key_id=%s", api, url.QueryEscape(serialNumber), url.QueryEscape(keyID), url.QueryEscape(keyFingerprint)))
+	resp, err := netClient.Get(
+		fmt.Sprintf("%s/certificates/%s?key_fingerprint=%s&key_id=%s&certificate=%s&certificate_type=%s",
+			api,
+			url.QueryEscape(serialNumber),
+			url.QueryEscape(keyID),
+			url.QueryEscape(keyFingerprint),
+			url.QueryEscape(cert),
+			url.QueryEscape(certType),
+		))
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"event":  "get certinfo",

--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -19,9 +19,9 @@ func init() {
 	checkPermissionCmd.Flags().String("serial-number", "", "the serial-number of the ssh certificate")
 	checkPermissionCmd.Flags().String("username", "", "the username of the user trying to authenticate")
 	checkPermissionCmd.Flags().String("key-id", "", "the key-id of the ssh certificate")
-	checkPermissionCmd.Flags().String("key-fingerprint", "", "The fingerprint's public key used at an ssh certificate.")
-	checkPermissionCmd.Flags().String("certificate", "", "The base64-encoded certificate.")
-	checkPermissionCmd.Flags().String("certificate-type", "", "The certificate type.")
+	checkPermissionCmd.Flags().String("key-fingerprint", "", "The fingerprint's public key used at an ssh certificate")
+	checkPermissionCmd.Flags().String("certificate", "", "The base64-encoded certificate")
+	checkPermissionCmd.Flags().String("certificate-type", "", "The certificate type")
 	checkPermissionCmd.Flags().String("api", "", "the endpoint GSH API to check certificate")
 }
 

--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -248,8 +248,8 @@ func getCertInfo(serialNumber, keyID, keyFingerprint, cert, certType, api string
 		fmt.Sprintf("%s/certificates/%s?key_fingerprint=%s&key_id=%s&certificate=%s&certificate_type=%s",
 			api,
 			url.QueryEscape(serialNumber),
-			url.QueryEscape(keyID),
 			url.QueryEscape(keyFingerprint),
+			url.QueryEscape(keyID),
 			url.QueryEscape(cert),
 			url.QueryEscape(certType),
 		))

--- a/agent/cmd/checkPermission.go
+++ b/agent/cmd/checkPermission.go
@@ -112,10 +112,10 @@ var checkPermissionCmd = &cobra.Command{
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"event":  "reading flag parameter from sshd",
-				"topic":  "key_fingerprint not informed",
-				"key":    "key_fingerprint",
+				"topic":  "key-fingerprint not informed",
+				"key":    "key-fingerprint",
 				"result": "fail",
-			}).Error("Failed to read key_fingerprint")
+			}).Error("Failed to read key-fingerprint")
 		}
 
 		cert, err := cmd.Flags().GetString("certificate")

--- a/api/handlers/certificates.go
+++ b/api/handlers/certificates.go
@@ -260,9 +260,7 @@ func (h AppHandler) CertCreate(c echo.Context) error {
 	cleanCert := strings.SplitN(signedKey, " ", 2)
 	cleanCert[1] = strings.Trim(cleanCert[1], "\n")
 	// cleanCert[1] AAAAHHNza...=
-	sha256sum := sha256.Sum256([]byte(cleanCert[1]))
-	hash := base64.RawStdEncoding.EncodeToString(sha256sum[:])
-	certRequest.CertFingerprint = hash
+	certRequest.CertFingerprint = certificateFingerprint(cleanCert[1])
 
 	// storing certificate in database
 	dbc := h.db.Create(certRequest)
@@ -339,8 +337,7 @@ func (h AppHandler) CertInfo(c echo.Context) error {
 	certType := c.QueryParam("certificate_type")
 
 	// generate certificate fingerprint
-	sha256sum := sha256.Sum256([]byte(cert))
-	certFingerprint := base64.RawStdEncoding.EncodeToString(sha256sum[:])
+	certFingerprint := certificateFingerprint(cert)
 	if cert == "" {
 		certFingerprint = ""
 	}
@@ -355,4 +352,11 @@ func (h AppHandler) CertInfo(c echo.Context) error {
 	}).First(&certRequest)
 
 	return c.JSON(http.StatusOK, map[string]string{"result": "success", "remote_user": certRequest.RemoteUser, "remote_host": certRequest.RemoteHost})
+}
+
+// certificateFingerprint generates an internal fingerprint for certificates
+func certificateFingerprint(certificate string) string {
+	sha256sum := sha256.Sum256([]byte(certificate))
+	hash := base64.RawStdEncoding.EncodeToString(sha256sum[:])
+	return hash
 }

--- a/types/certificate.go
+++ b/types/certificate.go
@@ -16,9 +16,10 @@ type CertRequest struct {
 	RemoteHost string    `json:"remote_host,omitempty" gorm:"column:remote_host;index:idx_remote_host"`
 	UserIP     string    `json:"user_ip,omitempty" gorm:"column:user_ip;index:idx_user_ip"`
 
-	ValidAfter  time.Time     `json:"-" gorm:"column:valid_after;index:idx_va"`
-	ValidBefore time.Time     `json:"-" gorm:"column:valid_before;index:idx_vb"`
-	PublicKey   ssh.PublicKey `json:"-" sql:"-" gorm:"-" db:"-"`
+	ValidAfter     time.Time     `json:"-" gorm:"column:valid_after;index:idx_va"`
+	ValidBefore    time.Time     `json:"-" gorm:"column:valid_before;index:idx_vb"`
+	PublicKey      ssh.PublicKey `json:"-" sql:"-" gorm:"-" db:"-"`
+	KeyFingerprint string        `json:"-" gorm:"column:key_fingerprint"`
 
 	// CA used in certificate sign
 	CAPublicKey   ssh.PublicKey `json:"-" sql:"-" gorm:"-" db:"-"`
@@ -26,9 +27,8 @@ type CertRequest struct {
 	KeyID         string        `json:"-" gorm:"column:key_id"`
 
 	//Certificate KeyID and Serial Number, after signed
-	CertKeyID       string `json:"-" gorm:"column:cert_key_id"`
-	SerialNumber    string `json:"-" gorm:"column:cert_serial_number"`
-	CertFingerprint string `json:"-" gorm:"column:cert_fingerprint"`
+	CertKeyID    string `json:"-" gorm:"column:cert_key_id"`
+	SerialNumber string `json:"-" gorm:"column:cert_serial_number"`
 
 	// Columns for database
 	ID         uint       `json:"-" gorm:"primary_key"`

--- a/types/certificate.go
+++ b/types/certificate.go
@@ -27,8 +27,10 @@ type CertRequest struct {
 	KeyID         string        `json:"-" gorm:"column:key_id"`
 
 	//Certificate KeyID and Serial Number, after signed
-	CertKeyID    string `json:"-" gorm:"column:cert_key_id"`
-	SerialNumber string `json:"-" gorm:"column:cert_serial_number"`
+	CertKeyID       string `json:"-" gorm:"column:cert_key_id"`
+	SerialNumber    string `json:"-" gorm:"column:cert_serial_number"`
+	CertType        string `json:"-" gorm:"column:cert_type"`
+	CertFingerprint string `json:"-" gorm:"column:cert_fingerprint"`
 
 	// Columns for database
 	ID         uint       `json:"-" gorm:"primary_key"`

--- a/types/certificate.go
+++ b/types/certificate.go
@@ -26,8 +26,9 @@ type CertRequest struct {
 	KeyID         string        `json:"-" gorm:"column:key_id"`
 
 	//Certificate KeyID and Serial Number, after signed
-	CertKeyID    string `json:"-" gorm:"column:cert_key_id"`
-	SerialNumber string `json:"-" gorm:"column:cert_serial_number"`
+	CertKeyID       string `json:"-" gorm:"column:cert_key_id"`
+	SerialNumber    string `json:"-" gorm:"column:cert_serial_number"`
+	CertFingerprint string `json:"-" gorm:"column:cert_fingerprint"`
 
 	// Columns for database
 	ID         uint       `json:"-" gorm:"primary_key"`


### PR DESCRIPTION
This PR adds support for the certificate and key's validation via gsh-agent and gsh-api.

## key's fingerprint validation
Currently, a certificate can be verified based on its signature (via OpenSSH) and its serial number and `key-id`.
The `key-id` is a user identification for your public key. When using an external CA, gsh-api receives `key-id` value from it. In this case, the `key-id` is composed of a string (for example `vault-approle` concatenated with the fingerprint (SHA256) of the public key in hexadecimal.
When using an internal CA, the `key-id` field receives other pieces of information for troubleshooting, so fingerprint identification becomes necessary.
Now, the fingerprint of the public key used is sent in its standard form separately from the `key-id`.

## certificate validation
Certificate validation occurs by sending it via gsh-agent to the gsh-api. Currently, a fingerprint (SHA256) is generated at the time of creating it and stored in the database.
When gsh-agent communicates with the gsh-api, it sends the certificate and the gsh-api calculates the fingerprint. The certificate is transmitted in complete form to allow adaptations of this fingerprint algorithm in the future.

Documentation updated:
- https://github.com/globocom/gsh/wiki/agent-configuration
- https://github.com/globocom/gsh/wiki/api-routes-get-certificates_certificate