### PR TITLE
WIP: api: [REFACT] Use the factory pattern to improve testability and extensibility

### DIFF
--- a/api/sshsigner/rsa/rsa.go
+++ b/api/sshsigner/rsa/rsa.go
@@ -1,0 +1,62 @@
+package rsa
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/globocom/gsh/api/sshsigner"
+	"golang.org/x/crypto/ssh"
+)
+
+// RSA implement functions at sshsigner interface
+type RSA struct {
+	CAPrivateKey []byte
+	CAPublicKey  []byte
+}
+
+// NewSSHSigner is an construtor for for RSA Signer
+func NewSSHSigner(conf map[string]string) (sshsigner.SSHSigner, error) {
+	return &RSA{}, nil
+}
+
+func init() {
+	sshsigner.Register("rsa", NewSSHSigner)
+}
+
+// RSA.CAPrivateKey = []byte(h.config.GetString("ca_private_key"))
+
+// SignUserSSHCertificate receives an ssh.Certificate for user and return a string with data (without \n at end)
+func (rsa *RSA) SignUserSSHCertificate(cert *ssh.Certificate) (string, error) {
+	// Parse the private key
+	sshCASigner, err := ssh.ParsePrivateKey(rsa.CAPrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("RSA SignUserSSHCertificate: error parsing ca key (%v)", err.Error())
+	}
+
+	err = cert.SignCert(rand.Reader, sshCASigner)
+	if err != nil {
+		return "", fmt.Errorf("RSA SignUserSSHCertificate: error sign user key (%v)", err.Error())
+	}
+	signedKey := string(ssh.MarshalAuthorizedKey(cert))
+
+	return signedKey, nil
+}
+
+// GetCAPublicKey returns public key from CA
+func (rsa *RSA) GetCAPublicKey() (string, error) {
+	if len(rsa.CAPublicKey) == 0 {
+		return "", fmt.Errorf("RSA GetCAPublicKey: error getting CA public key")
+	}
+	return string(rsa.CAPublicKey), nil
+}
+
+// IsConfigured returns if CA is configured
+func (rsa *RSA) IsConfigured() error {
+	if len(rsa.CAPublicKey) == 0 {
+		return fmt.Errorf("RSA IsConfigured: error getting CA public key")
+	}
+	if len(rsa.CAPrivateKey) == 0 {
+		return fmt.Errorf("RSA IsConfigured: error getting CA private key")
+	}
+	return nil
+}

--- a/api/sshsigner/sshsigner.go
+++ b/api/sshsigner/sshsigner.go
@@ -1,0 +1,30 @@
+package sshsigner
+
+import (
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHSigner is interface with functions that all signers must implement
+type SSHSigner interface {
+	IsConfigured() error
+	SignUserSSHCertificate(c *ssh.Certificate) (string, error)
+	GetCAPublicKey() (string, error)
+}
+
+// SignerFactory is a factory of supported signers
+type SignerFactory func(conf map[string]string) (SSHSigner, error)
+
+// signerFactories is a map with all supported signers
+var signerFactories = make(map[string]SignerFactory)
+
+// Register is responsible for register new SSHSigners at signerFactories map
+func Register(name string, factory SignerFactory) {
+	if factory == nil {
+		panic("Signer factory does not exist (" + name + ")")
+	}
+	_, registered := signerFactories[name]
+	if registered {
+		// log.Errorf("Datastore factory %s already registered. Ignoring.", name)
+	}
+	signerFactories[name] = factory
+}


### PR DESCRIPTION
This PR makes a refactoring of the SSH signer logic to make them into a separate package. This case is using the factory pattern to make this part of code more extensibility.


Refs:
- https://matthewbrown.io/2016/01/23/factory-pattern-in-golang/
- https://nathanleclaire.com/blog/2015/10/10/interfaces-and-composition-for-effective-unit-testing-in-golang/