### PR TITLE
cli: [FIX] Remove duplicated error message

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -60,7 +60,6 @@ on OpenSSH remote systems.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR fix duplicated error messages displayed when error occurs.

```
$ gsh role
Error: unknown command "role" for "gsh"

Did you mean this?
	role-add
	role-assign
	role-dissociate
	role-list
	role-list-me
	role-list-users
	role-remove

Run 'gsh --help' for usage.
unknown command "role" for "gsh"

Did you mean this?
	role-add
	role-assign
	role-dissociate
	role-list
	role-list-me
	role-list-users
	role-remove
```

After this fix, errors looks like:

```
$ gsh  role
Error: unknown command "role" for "gsh"

Did you mean this?
	role-add
	role-assign
	role-dissociate
	role-list
	role-list-me
	role-list-users
	role-remove

Run 'gsh --help' for usage.
```